### PR TITLE
Updated sort.rs

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -769,7 +769,7 @@ impl DisplayAs for SortExec {
                         write!(
                             f,
                             // TODO should this say topk?
-                            "SortExec: fetch={fetch}, expr=[{}]",
+                            "SortExec: TopK(fetch={fetch}), expr=[{}]",
                             expr.join(",")
                         )
                     }


### PR DESCRIPTION
solves: #7750

Replaced `SortExec: fetch={fetch}, expr=[{}]` with 'SortExec: TopK(fetch={fetch}), expr=[{}]' in [sort.rs](https://github.com/apache/arrow-datafusion/blob/main/datafusion/physical-plan/src/sorts/sort.rs) file